### PR TITLE
Zoom button fix

### DIFF
--- a/app/src/UI/Footer.css
+++ b/app/src/UI/Footer.css
@@ -6,10 +6,12 @@
     margin: 0;
     align-items: center;
     justify-content: start;
+
+    a{
+        color: #036;
+        text-decoration: none;
+        margin-left: 32px;
+    }
+
 }
 
-a{
-    color: #036;
-    text-decoration: none;
-    margin-left: 32px;
-}

--- a/app/src/UI/Map.tsx
+++ b/app/src/UI/Map.tsx
@@ -206,6 +206,7 @@ export const MapPanel: React.FC = () => {
         center={defaultLocation}
         zoom={13}
         scrollWheelZoom={false}
+        zoomControl={true}
       >
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'


### PR DESCRIPTION
Previously, the box containing the zoom in/out buttons was wider than the actual buttons on the left. This has been fixed.