### PR TITLE
Directly submit sightings to API (i.e. remove local save + sync)

### DIFF
--- a/app/src/UI/Sightings.tsx
+++ b/app/src/UI/Sightings.tsx
@@ -22,12 +22,7 @@ export const Sightings = (props: any) => {
     <div className="sightingContainer">
       <span className="wrapper">
         <div className="sightingHeader">
-          <div className="sightingHeadingText">
-            <h2>All Sightings</h2>
-          </div>
-          <button className="syncButton" onClick={() => dispatch({ type: SYNC_SIGHTINGS_TO_DB, payload: {} })}>
-            Sync
-          </button>
+          <h2 className="sightingHeadingText">All Sightings</h2>
         </div>
         <div className="sightingText">
           {storedSightings?.length > 0 ?

--- a/app/src/UI/Sightings.tsx
+++ b/app/src/UI/Sightings.tsx
@@ -31,14 +31,13 @@ export const Sightings = (props: any) => {
                 <Accordion key={sighting.id} className="sighting">
                   <AccordionSummary className="sightingHeader" aria-controls="panel-content">
                     <div className="sightingDate">{formatDateString(sighting.dateFrom)} to {formatDateString(sighting.dateTo)}</div>
-                    <div className="sightingStatus">&nbsp;({sighting.status})</div>
                   </AccordionSummary>
                   <AccordionDetails>
                     <div>{sighting.region} {sighting.subRegion}</div>
                     <div>Moose count: {sighting.mooseCount}</div>
                     {/* TODO: tick hair loss not yet implemented */}
                     {/* <div>Tick hair loss: {sighting.tickHairLoss} </div> */}
-                    <div>Sync date: {sighting.syncDate ?? '(not synced)'}</div>
+                    <div>Sync date: {formatDateString(sighting.syncDate)}</div>
                   </AccordionDetails>
                 </Accordion>
               );

--- a/app/src/state/reducers/MooseSightings.ts
+++ b/app/src/state/reducers/MooseSightings.ts
@@ -123,7 +123,7 @@ function createMooseSightingStateReducer(
       case SIGHTING_SYNC_SUCCESSFUL: {
         return {
           ...state,
-          allSightings: state.allSightings.map((sighting) => { return {...sighting, 'status':"Synced"} })
+          allSightings: state.allSightings.map((sighting) => { return {...sighting, 'status':"Synced", syncDate: new Date()} })
         }
       }
       case CLEAR_CURRENT_MOOSE_SIGHTING: {

--- a/app/src/state/sagas/mooseSightingsSaga.ts
+++ b/app/src/state/sagas/mooseSightingsSaga.ts
@@ -55,8 +55,7 @@ function* handle_USER_SAVE_SIGHTINGS(action: any) {
 }
 
 function* handle_USER_SAVE_SIGHTINGS_SUCCESS(action: any) {
-  yield put({ type: WRITE_SIGHTINGS_TO_DISK });
-  yield put({ type: CLEAR_CURRENT_MOOSE_SIGHTING });
+  yield put({ type: SYNC_SIGHTINGS_TO_DB});
 }
 
 function prepareSightingsForApi(sightings: any) {

--- a/app/src/util.ts
+++ b/app/src/util.ts
@@ -1,6 +1,11 @@
 export const formatDateString = (date: Date | string): string => {
-  if (date instanceof Date)
+  try {
+    if (date instanceof Date)
     return date.toISOString().slice(0,10);
   else
     return date.split("T")[0];
+  } catch {
+    // failsafe, so that we at least don't crash the entire page
+    return '';
+  }
 }


### PR DESCRIPTION
Previously, a sighting had to be saved and then synced separately on the Sightings page. This is no longer the case - clicking "Save sighting" now directly triggers the API call that saves the sighting to the database. UI elements related to this "save + sync" flow have been removed as appropriate.

The `syncDate` is now populated once the API call succeeds.