### PR TITLE
Remove zoom plugin autoload

### DIFF
--- a/app/android/app/src/main/java/com/example/app/MainActivity.java
+++ b/app/android/app/src/main/java/com/example/app/MainActivity.java
@@ -1,15 +1,6 @@
 package com.example.app;
 
 import com.getcapacitor.BridgeActivity;
-import com.example.capacitorzoomandroid.ZoomPlugin;
-import com.getcapacitor.Plugin;
-import android.os.Bundle;
-import java.util.ArrayList;
 
 public class MainActivity extends BridgeActivity {
-    super.onCreate(savedInstanceState);
-        this.init(savedInstanceState, new ArrayList<Class<? extends Plugin>>() {{
-            add(ZoomPlugin.class);
-        }});
-    }
 }


### PR DESCRIPTION
Capacitor auto-loads plugins as of v3, so manual registration of the zoom plugin has been removed. It was also preventing Android Studio from building the app due to errors.

https://capacitorjs.com/docs/updating/3-0#switch-to-automatic-android-plugin-loading

That being said, no zoom functionality has been implemented yet so the plugin isn't really doing anything at the moment anwyay.