### PR TITLE
Sightings page: update sighting heading

### DIFF
--- a/app/src/UI/Sightings.tsx
+++ b/app/src/UI/Sightings.tsx
@@ -30,7 +30,7 @@ export const Sightings = (props: any) => {
               return (
                 <Accordion key={sighting.id} className="sighting">
                   <AccordionSummary className="sightingHeader" aria-controls="panel-content">
-                    <div className="sightingDate">{formatDateString(sighting.dateFrom)} to {formatDateString(sighting.dateTo)}</div>
+                    <div className="sightingDate">{formatDateString(sighting.date)} ({sighting.hoursOut} {sighting.hoursOut === 1 ? 'hour' : 'hours'})</div>
                   </AccordionSummary>
                   <AccordionDetails>
                     <div>{sighting.region} {sighting.subRegion}</div>


### PR DESCRIPTION
Updates the sightings page so that each entry's heading displays the date and the hours out.

Previously, the from/to dates were displayed - the "add sighting" form has since been updated so these fields no longer exist, resulting in a heading that reads ` to ` (the from/to dates get inserted as empty strings).
