### PR TITLE
Swap out compileSdkVersion for compileSdk; bump up compileSdk from 33 to 34

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -2,9 +2,9 @@ apply plugin: 'com.android.application'
 
 android {
     namespace "ca.bc.gov.fw.wildlifetracker"
-    compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig {
         applicationId "ca.bc.gov.fw.wildlifetracker"
+        compileSdk = rootProject.ext.compileSdkVersion
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/app/android/variables.gradle
+++ b/app/android/variables.gradle
@@ -1,6 +1,6 @@
 ext {
     minSdkVersion = 22
-    compileSdkVersion = 33
+    compileSdkVersion = 34
     targetSdkVersion = 34
     androidxActivityVersion = '1.7.0'
     androidxAppCompatVersion = '1.6.1'


### PR DESCRIPTION
* Bump compile SDK version from `33` to `34` in order to accommodate Capacitor updates in previous commit on `main`
* Swap out `compileSdkVersion` for `compileSdk` as it's since been deprecated