### PR TITLE
Bump up android versionCode

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -7,7 +7,7 @@ android {
         compileSdk = rootProject.ext.compileSdkVersion
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
+        versionCode 5
         versionName "2.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {


### PR DESCRIPTION
Bumping up `versionCode` in android build.gradle again - the old MooseTracker was at `versionCode=4` (previous PR set `versionCode=2`)