### PR TITLE
CSS - 'add moose' form fixes

### DIFF
--- a/.github/workflows/app_state_test.yml
+++ b/.github/workflows/app_state_test.yml
@@ -3,7 +3,6 @@ on: [pull_request]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -12,12 +11,12 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.11.0'
+          node-version: "20.11.0"
 
-      - name: Install 
+      - name: Install
         run: |
           cd app
-          npm install
+          npm install --legacy-peer-deps
 
       - name: Test
         env:
@@ -25,4 +24,3 @@ jobs:
         run: |
           cd app
           npm run test
-

--- a/app/src/UI/Form.css
+++ b/app/src/UI/Form.css
@@ -1,7 +1,7 @@
 .formPanel {
   display: flex;
   flex-direction: column;
-  width: 100%; 
+  width: 100%;
   justify-content: center;
   text-align: center;
   background-color: rgba(0, 0, 0, .03);
@@ -31,12 +31,15 @@
 
 .formInput {
   display: grid;
-  padding-top: 1rem;
+  padding: 1rem;
   justify-content: center;
   align-items: center;
-  grid-template-columns: .1fr .1fr .1fr;
+  grid-template-columns: repeat(3, 1fr);
+  margin: 0 auto;
   row-gap: 1rem;
-  column-gap: 1rem;
+  column-gap: 0.5rem;
+  max-width: 300px; 
+  margin: 0 auto; 
   label {
     font-size: 1.5em;
   }
@@ -46,17 +49,16 @@
   .columnRight {
     display: flex;
     flex-direction: row;
-
   }
   .count {
-    font-size: 1.5rem
+    font-size: 1.5rem;
   }
   .regionSelectors {
     display: flex;
     flex-direction: column;
-    align-items: flex-end; 
+    align-items: flex-end;
     justify-content: end;
-    gap: 1em; 
+    gap: 1em;
     grid-column: span 2;
     padding-right: 0.5rem;
   }
@@ -103,17 +105,24 @@ input[type="date" i] {
   margin: .25em;
 }
 
+/* Tablet and Larger Screen Adjustments */
 @media (min-width: 600px) {
   .formPanel {
     height: 85vh;
   }
+  
   .formHeader {
     font-size: 1.2rem;
   }
-  .formInput div {
-    padding: .5em;
+
+  .formInput {
+    max-width: 600px; /* Constrain the width for tablets */
   }
-  .regionSelectors {
-    grid-column: none;
+}
+
+/* Desktop Adjustments */
+@media (min-width: 900px) {
+  .formInput {
+    max-width: 800px; /* Further constrain the width for desktop */
   }
 }

--- a/app/src/UI/Form.tsx
+++ b/app/src/UI/Form.tsx
@@ -74,14 +74,13 @@ export const FormPanel = () => {
           <label>
             <span className="formContent">Date: </span>
           </label>
-          <div></div>
           <input
             type="date"
             id="date"
             value={date ? date.toISOString().split("T")[0] : ""}
             onChange={handlefromDateChange}
           />
-          
+          <div></div>
           <label>
             <span className="formContent">Bulls: </span>
           </label>

--- a/app/src/UI/RegionSelector.tsx
+++ b/app/src/UI/RegionSelector.tsx
@@ -76,7 +76,7 @@ export const RegionSelector = () => {
           value={selectedRegion}
           onChange={handleRegionSelect}
         >
-          <option>-- select a region --</option>
+          <option>- select a region -</option>
           {regionNamesArray.map((region: any) => (
             <option key={region} value={region}>
               {region}
@@ -93,7 +93,7 @@ export const RegionSelector = () => {
         >
           {/* This section filters the options array so only subregions of the selected region are shown*/}
           {/* The result is then sorted based on management region id (ex id : "1-12") and an option entry generated for each*/}
-          <option value="">-- select a subregion --</option>
+          <option value="">- select a subregion -</option>
           {options
             .filter(
               (property: any) =>


### PR DESCRIPTION
- Ensure text for drop down fits nicely on all size devices. Makes whole drop down readable if screen is wide enough when a large sub-region is chosen
- Fixes test by adding `--legacy-peer-deps` to `npm install`