### PR TITLE
Show detailed moose counts on sightings page

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         compileSdk = rootProject.ext.compileSdkVersion
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 6
-        versionName "2.3"
+        versionCode 7
+        versionName "2.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/app/src/UI/Sightings.tsx
+++ b/app/src/UI/Sightings.tsx
@@ -34,7 +34,10 @@ export const Sightings = (props: any) => {
                   </AccordionSummary>
                   <AccordionDetails>
                     <div>{sighting.region} {sighting.subRegion}</div>
-                    <div>Moose count: {sighting.mooseCount}</div>
+                    <div>Bulls: {sighting.bullCount ?? 0}</div>
+                    <div>Cows: {sighting.cowCount ?? 0}</div>
+                    <div>Calves: {sighting.calfCount ?? 0}</div>
+                    <div>Unknown: {sighting.unknownCount ?? 0}</div>
                     {/* TODO: tick hair loss not yet implemented */}
                     {/* <div>Tick hair loss: {sighting.tickHairLoss} </div> */}
                     <div>Sync date: {formatDateString(sighting.syncDate)}</div>

--- a/app/src/UI/Sightings.tsx
+++ b/app/src/UI/Sightings.tsx
@@ -40,7 +40,6 @@ export const Sightings = (props: any) => {
                     <div>Unknown: {sighting.unknownCount ?? 0}</div>
                     {/* TODO: tick hair loss not yet implemented */}
                     {/* <div>Tick hair loss: {sighting.tickHairLoss} </div> */}
-                    <div>Sync date: {formatDateString(sighting.syncDate)}</div>
                   </AccordionDetails>
                 </Accordion>
               );


### PR DESCRIPTION
It was previously attempting to displaying `mooseCount` (which no longer exists), so it would show up empty. This has been replaced by a detailed breakdown of bulls / cows / calves.

The sync date has also been removed from the sightings page - this was a holdover from earlier when sightings could be added locally to be synced later. This is no longer the case.