### PR TITLE
"Add Moose" page: move placeholder div next to date picker

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -7,7 +7,7 @@ android {
         compileSdk = rootProject.ext.compileSdkVersion
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 7
+        versionCode 8
         versionName "2.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {

--- a/app/src/UI/Form.tsx
+++ b/app/src/UI/Form.tsx
@@ -74,13 +74,13 @@ export const FormPanel = () => {
           <label>
             <span className="formContent">Date: </span>
           </label>
+          <div></div>
           <input
             type="date"
             id="date"
             value={date ? date.toISOString().split("T")[0] : ""}
             onChange={handlefromDateChange}
           />
-          <div></div>
           <label>
             <span className="formContent">Bulls: </span>
           </label>


### PR DESCRIPTION
In #119 (specifically e5ca80b8d18e1a59f446c2498c201593800ce029), a placeholder `<div>` next to the date picker on the "Add Moose" page was moved in order to prevent the form from spilling over the side on small screens.

This was reverted sometime between then and now, causing the spillover issue to resurface. This has been fixed here.